### PR TITLE
fix build failure with libfdt-devel installed

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -240,7 +240,7 @@ endif # !LOGO_BMP
 #
 HOST_EXTRACFLAGS += -include $(srctree)/include/libfdt_env.h \
 		$(patsubst -I%,-idirafter%, $(filter -I%, $(UBOOTINCLUDE))) \
-		-I$(srctree)/lib/libfdt \
+		-I$(srctree)/scripts/dtc/libfdt \
 		-I$(srctree)/tools \
 		-DUSE_HOSTCC \
 		-D__KERNEL_STRICT_NAMES \


### PR DESCRIPTION
This is a port of a `u-boot` patch from `buildroot`:
http://lists.busybox.net/pipermail/buildroot/2018-March/215420.html

The upstream `rockchip-linux/u-boot` includes this patch.
https://github.com/rockchip-linux/u-boot/blob/next-dev/tools/Makefile#L256

When trying to build `u-boot` on a host that has `libfdt-devel` installed, it seems to generate double-definition errors:
```
    /usr/include/libfdt_env.h:70:30: error: conflicting types for ‘fdt64_t’
     typedef uint64_t FDT_BITWISE fdt64_t;
                                  ^~~~~~~
    In file included from <command-line>:0:0:
    ././include/libfdt_env.h:19:16: note: previous declaration of ‘fdt64_t’ was here
     typedef __be64 fdt64_t;
                    ^~~~~~~
```

This patch fixes it.