### PR TITLE
fix generate_bl31_node failed to get list of *.bin files

### DIFF
--- a/arch/arm/mach-rockchip/make_fit_atf.sh
+++ b/arch/arm/mach-rockchip/make_fit_atf.sh
@@ -76,7 +76,7 @@ function generate_kfdt_node()
 function generate_bl31_node()
 {
 	NUM=1
-	for NAME in `ls -l bl31_0x*.bin | sort --key=5 -nr | awk '{ print $9 }'`
+	for NAME in `ls -l bl31_0x*.bin | sort --key=5 -nr | awk '{ print $10 }'`
 	do
 		ATF_LOAD_ADDR=`echo ${NAME} | awk -F "_" '{ printf $2 }' | awk -F "." '{ printf $1 }'`
 		# only atf-1 support compress


### PR DESCRIPTION
This PR is subject to fixing the issue of failure to build u-boot for the rk3568-rock-3a  board.
Issue:
```
./build/mk-uboot.sh rk3568-rock-3a

---
FATAL ERROR: Couldn't open "./09:46": No such file or directory
./tools/mkimage: Can't read u-boot.itb.tmp: Invalid argument
make: *** [Makefile:1051: u-boot.itb] Error 255
 MAKE UBOOT IMAGE FAILED.
```
Root cause:
- The function `generate_bl31_node` was failed to get the file name of `bl31_0x*.bin` due to incorrect index for awk.

```,
ls -l bl31_0x*.bin | sort --key=5 -nr | awk '{ print $9 }'
09:46
09:46
09:46
09:46
09:46
```
Solution:
- Correct the index to get the result in awk

```,
ls -l bl31_0x*.bin | sort --key=5 -nr | awk '{ print $10 }'
bl31_0x00040000.bin
bl31_0x00068000.bin
bl31_0xfdcd0000.bin
bl31_0xfdcc9000.bin
bl31_0x00066000.bin
```


