### PR TITLE
arm64: dts: fix vcc_3v3 for e25

### DIFF
--- a/arch/arm/dts/rk3568-radxa-rock-3-compute-module-plus.dtsi
+++ b/arch/arm/dts/rk3568-radxa-rock-3-compute-module-plus.dtsi
@@ -372,6 +372,7 @@
 				regulator-boot-on;
 				regulator-name = "vcc_3v3";
 				regulator-state-mem {
+					u-boot,dm-pre-reloc;
 					regulator-off-in-suspend;
 				};
 			};


### PR DESCRIPTION
need this fix to enable npu on kernel 5.10