### PR TITLE
give SD higher boot priority than NVME

### DIFF
--- a/include/configs/rockchip-common.h
+++ b/include/configs/rockchip-common.h
@@ -58,13 +58,20 @@
 	BOOT_TARGET_DEVICES_references_MTD_without_CONFIG_CMD_MTD_BLK
 #endif
 
-/* First try to boot from SD (index 1), then eMMC (index 0) */
+/* First try to boot from SD (index 1), then NVME (if CMD_NVME is enabled), then eMMC (index 0) */
 #if CONFIG_IS_ENABLED(CMD_MMC)
-	#define BOOT_TARGET_MMC(func) \
+#if CONFIG_IS_ENABLED(CMD_NVME)
+	#define BOOT_TARGET_NVME_MMC(func) \
 		func(MMC, mmc, 1) \
+		func(NVME, nvme, 0) \
 		func(MMC, mmc, 0)
 #else
-	#define BOOT_TARGET_MMC(func)
+	#define BOOT_TARGET_NVME_MMC(func) \
+		func(MMC, mmc, 1) \
+		func(MMC, mmc, 0)
+#endif
+#else
+	#define BOOT_TARGET_NVME_MMC(func)
 #endif
 
 #if CONFIG_IS_ENABLED(CMD_MTD_BLK)
@@ -80,12 +87,6 @@
 	#define BOOT_TARGET_RKNAND(func) func(RKNAND, rknand, 0)
 #else
 	#define BOOT_TARGET_RKNAND(func)
-#endif
-
-#if CONFIG_IS_ENABLED(CMD_NVME)
-	#define BOOT_TARGET_NVME(func) func(NVME, nvme, 0)
-#else
-	#define BOOT_TARGET_NVME(func)
 #endif
 
 #if CONFIG_IS_ENABLED(CMD_USB)
@@ -107,8 +108,7 @@
 #endif
 
 #define BOOT_TARGET_DEVICES(func) \
-	BOOT_TARGET_NVME(func) \
-	BOOT_TARGET_MMC(func) \
+	BOOT_TARGET_NVME_MMC(func) \
 	BOOT_TARGET_MTD(func) \
 	BOOT_TARGET_RKNAND(func) \
 	BOOT_TARGET_USB(func) \
@@ -156,10 +156,10 @@
 
 #define RKIMG_DET_BOOTDEV \
 	"rkimg_bootdev=" \
-	"if nvme dev 0; then " \
-		"setenv devtype nvme; setenv devnum 0; echo Boot from nvme;" \
-	"elif mmc dev 1 && rkimgtest mmc 1; then " \
+	"if mmc dev 1 && rkimgtest mmc 1; then " \
 		"setenv devtype mmc; setenv devnum 1; echo Boot from SDcard;" \
+	"elif nvme dev 0; then " \
+		"setenv devtype nvme; setenv devnum 0; echo Boot from nvme;" \
 	"elif mmc dev 0; then " \
 		"setenv devtype mmc; setenv devnum 0;" \
 	"elif mtd_blk dev 0; then " \


### PR DESCRIPTION
Before this commit NVME has the highest boot priority than all the devices. I think the easier one device can get plugged/unplugged, the higher boot priority it should have. So sd card should have the highest boot priority, and then NVME SSD, and then emmc.
I tested on rock5b, when sd card and nvme ssd are both inserted, the board will boot into system on sd card.