### PR TITLE
Disable gmac1 of Radxa CM3 Rpi CM4 IO board,

### DIFF
--- a/arch/arm/dts/rk3566-radxa-cm3-rpi-cm4-io.dts
+++ b/arch/arm/dts/rk3566-radxa-cm3-rpi-cm4-io.dts
@@ -106,7 +106,7 @@
 	snps,reset-delays-us = <0 20000 100000>;
 	tx_delay = <0x46>;
 	rx_delay = <0x2e>;
-	status = "okay";
+	status = "disabled";
 };
 
 &hdmi {


### PR DESCRIPTION
for uboot does not recognize the network adapter,
this will cause the kernel cannot obtain an ip address after startup.