### PR TITLE
configs: rk3308: Fix the bug of using 256M DDR

### DIFF
--- a/include/configs/rk3308_common.h
+++ b/include/configs/rk3308_common.h
@@ -16,11 +16,11 @@
 #define ENV_MEM_LAYOUT_SETTINGS \
 	"scriptaddr=0x00500000\0" \
 	"pxefile_addr_r=0x00600000\0" \
-	"fdt_addr_r=0x1d000000\0" \
-	"fdtoverlay_addr_r=0x1f000000\0" \
-	"kernel_addr_r=0x00680000\0" \
-	"ramdisk_addr_r=0x04000000\0" \
-	"kernel_comp_addr_r=0x10000000\0" \
+	"fdt_addr_r=0x01d00000\0" \
+	"fdtoverlay_addr_r=0x01f00000\0" \
+	"kernel_addr_r=0x02080000\0" \
+	"ramdisk_addr_r=0x06000000\0" \
+	"kernel_comp_addr_r=0x08000000\0" \
 	"kernel_comp_size=0x2000000\0"
 
 #define CFG_EXTRA_ENV_SETTINGS \

--- a/include/configs/rk3328_common.h
+++ b/include/configs/rk3328_common.h
@@ -16,7 +16,8 @@
 #define ENV_MEM_LAYOUT_SETTINGS \
 	"scriptaddr=0x00500000\0" \
 	"pxefile_addr_r=0x00600000\0" \
-	"fdt_addr_r=0x01f00000\0" \
+	"fdt_addr_r=0x01d00000\0" \
+	"fdtoverlay_addr_r=0x01f00000\0" \
 	"kernel_addr_r=0x02080000\0" \
 	"ramdisk_addr_r=0x06000000\0" \
 	"kernel_comp_addr_r=0x08000000\0" \


### PR DESCRIPTION
The address set by the relevant environment variables exceeds the capacity of the DDR.