### PR TITLE
UPSTREAM: phy: Track power-on and init counts in uclass

### DIFF
--- a/drivers/phy/phy-uclass.c
+++ b/drivers/phy/phy-uclass.c
@@ -8,12 +8,96 @@
 #include <common.h>
 #include <dm.h>
 #include <generic-phy.h>
+#include <linux/list.h>
+
+/**
+ * struct phy_counts - Init and power-on counts of a single PHY port
+ *
+ * This structure is used to keep track of PHY initialization and power
+ * state change requests, so that we don't power off and deinitialize a
+ * PHY instance until all of its users want it done. Otherwise, multiple
+ * consumers using the same PHY port can cause problems (e.g. one might
+ * call power_off() after another's exit() and hang indefinitely).
+ *
+ * @id: The PHY ID within a PHY provider
+ * @power_on_count: Times generic_phy_power_on() was called for this ID
+ *                  without a matching generic_phy_power_off() afterwards
+ * @init_count: Times generic_phy_init() was called for this ID
+ *              without a matching generic_phy_exit() afterwards
+ * @list: Handle for a linked list of these structures corresponding to
+ *        ports of the same PHY provider
+ */
+struct phy_counts {
+	unsigned long id;
+	int power_on_count;
+	int init_count;
+	struct list_head list;
+};
 
 DECLARE_GLOBAL_DATA_PTR;
 
 static inline struct phy_ops *phy_dev_ops(struct udevice *dev)
 {
 	return (struct phy_ops *)dev->driver->ops;
+}
+
+static struct phy_counts *phy_get_counts(struct phy *phy)
+{
+	struct list_head *uc_priv;
+	struct phy_counts *counts;
+
+	if (!generic_phy_valid(phy))
+		return NULL;
+
+	uc_priv = dev_get_uclass_priv(phy->dev);
+	list_for_each_entry(counts, uc_priv, list)
+		if (counts->id == phy->id)
+			return counts;
+
+	return NULL;
+}
+
+static int phy_alloc_counts(struct phy *phy)
+{
+	struct list_head *uc_priv;
+	struct phy_counts *counts;
+
+	if (!generic_phy_valid(phy))
+		return 0;
+	if (phy_get_counts(phy))
+		return 0;
+
+	uc_priv = dev_get_uclass_priv(phy->dev);
+	counts = kzalloc(sizeof(*counts), GFP_KERNEL);
+	if (!counts)
+		return -ENOMEM;
+
+	counts->id = phy->id;
+	counts->power_on_count = 0;
+	counts->init_count = 0;
+	list_add(&counts->list, uc_priv);
+
+	return 0;
+}
+
+static int phy_uclass_pre_probe(struct udevice *dev)
+{
+	struct list_head *uc_priv = dev_get_uclass_priv(dev);
+
+	INIT_LIST_HEAD(uc_priv);
+
+	return 0;
+}
+
+static int phy_uclass_pre_remove(struct udevice *dev)
+{
+	struct list_head *uc_priv = dev_get_uclass_priv(dev);
+	struct phy_counts *counts, *next;
+
+	list_for_each_entry_safe(counts, next, uc_priv, list)
+		kfree(counts);
+
+	return 0;
 }
 
 static int generic_phy_xlate_offs_flags(struct phy *phy,
@@ -74,6 +158,12 @@ int generic_phy_get_by_index(struct udevice *dev, int index,
 		goto err;
 	}
 
+	ret = phy_alloc_counts(phy);
+	if (ret) {
+		debug("phy_alloc_counts() failed: %d\n", ret);
+		goto err;
+	}
+
 	return 0;
 
 err:
@@ -98,13 +188,30 @@ int generic_phy_get_by_name(struct udevice *dev, const char *phy_name,
 
 int generic_phy_init(struct phy *phy)
 {
+	struct phy_counts *counts;
 	struct phy_ops const *ops;
+	int ret;
 
 	if (!generic_phy_valid(phy))
 		return 0;
 	ops = phy_dev_ops(phy->dev);
+	if (!ops->init)
+		return 0;
 
-	return ops->init ? ops->init(phy) : 0;
+	counts = phy_get_counts(phy);
+	if (counts->init_count > 0) {
+		counts->init_count++;
+		return 0;
+	}
+
+	ret = ops->init(phy);
+	if (ret)
+		dev_err(phy->dev, "PHY: Failed to init %s: %d.\n",
+			phy->dev->name, ret);
+	else
+		counts->init_count = 1;
+
+	return 0;
 }
 
 int generic_phy_reset(struct phy *phy)
@@ -120,35 +227,90 @@ int generic_phy_reset(struct phy *phy)
 
 int generic_phy_exit(struct phy *phy)
 {
+	struct phy_counts *counts;
 	struct phy_ops const *ops;
+	int ret;
 
 	if (!generic_phy_valid(phy))
 		return 0;
 	ops = phy_dev_ops(phy->dev);
+	if (!ops->exit)
+		return 0;
 
-	return ops->exit ? ops->exit(phy) : 0;
+	counts = phy_get_counts(phy);
+	if (counts->init_count == 0)
+		return 0;
+	if (counts->init_count > 1) {
+		counts->init_count--;
+		return 0;
+	}
+
+	ret = ops->exit(phy);
+	if (ret)
+		dev_err(phy->dev, "PHY: Failed to exit %s: %d.\n",
+			phy->dev->name, ret);
+	else
+		counts->init_count = 0;
+
+	return 0;
 }
 
 int generic_phy_power_on(struct phy *phy)
 {
+	struct phy_counts *counts;
 	struct phy_ops const *ops;
+	int ret;
 
 	if (!generic_phy_valid(phy))
 		return 0;
 	ops = phy_dev_ops(phy->dev);
+	if (!ops->power_on)
+		return 0;
 
-	return ops->power_on ? ops->power_on(phy) : 0;
+	counts = phy_get_counts(phy);
+	if (counts->power_on_count > 0) {
+		counts->power_on_count++;
+		return 0;
+	}
+
+	ret = ops->power_on(phy);
+	if (ret)
+		dev_err(phy->dev, "PHY: Failed to power on %s: %d.\n",
+			phy->dev->name, ret);
+	else
+		counts->power_on_count = 1;
+
+	return 0;
 }
 
 int generic_phy_power_off(struct phy *phy)
 {
+	struct phy_counts *counts;
 	struct phy_ops const *ops;
+	int ret;
 
 	if (!generic_phy_valid(phy))
 		return 0;
 	ops = phy_dev_ops(phy->dev);
+	if (!ops->power_off)
+		return 0;
 
-	return ops->power_off ? ops->power_off(phy) : 0;
+	counts = phy_get_counts(phy);
+	if (counts->power_on_count == 0)
+		return 0;
+	if (counts->power_on_count > 1) {
+		counts->power_on_count--;
+		return 0;
+	}
+
+	ret = ops->power_off(phy);
+	if (ret)
+		dev_err(phy->dev, "PHY: Failed to power off %s: %d.\n",
+			phy->dev->name, ret);
+	else
+		counts->power_on_count = 0;
+
+	return 0;
 }
 
 int generic_phy_configure(struct phy *phy, union phy_configure_opts *opts)
@@ -196,4 +358,7 @@ int generic_phy_set_mode_ext(struct phy *phy, enum phy_mode mode, int submode)
 UCLASS_DRIVER(phy) = {
 	.id		= UCLASS_PHY,
 	.name		= "phy",
+	.pre_probe	= phy_uclass_pre_probe,
+	.pre_remove	= phy_uclass_pre_remove,
+	.per_device_auto_alloc_size = sizeof(struct list_head),
 };


### PR DESCRIPTION
On boards using the RK3399 SoC, the USB OHCI and EHCI controllers share the same PHY device instance. While these controllers are being stopped they both attempt to power-off and deinitialize it, but trying to power-off the deinitialized PHY device results in a hang. This usually happens just before booting an OS, and can be explicitly triggered by running "usb start; usb stop" in the U-Boot shell.

Implement a uclass-wide counting mechanism for PHY initialization and power state change requests, so that we don't power-off/deinitialize a PHY instance until all of its users want it done. The Allwinner A10 USB PHY driver does this counting in-driver, remove those parts in favour of this in-uclass implementation.

The sandbox PHY operations test needs some changes since the uclass will no longer call into the drivers for actions matching its tracked state (e.g. powering-off a powered-off PHY). Update that test, and add a new one which simulates multiple users of a single PHY.

The major complication here is that PHY handles aren't deduplicated per instance, so the obvious idea of putting the counts in the PHY handles don't immediately work. It seems possible to bind a child udevice per PHY instance to the PHY provider and deduplicate the handles in each child's uclass-private areas, like in the CLK framework. An alternative approach could be to use those bound child udevices themselves as the PHY handles. Instead, to avoid the architectural changes those would require, this patch solves things by dynamically allocating a list of structs (one per instance) in the provider's uclass-private area.

Change-Id: If25109d441b4d93638b450f9137eccd159935aa8

Reviewed-by: Simon Glass <sjg@chromium.org>
Tested-by: Peter Robinson <pbrobinson@gmail.com> - Rock960