### PR TITLE
Fix build with -Werror

### DIFF
--- a/common/edid.c
+++ b/common/edid.c
@@ -3579,7 +3579,7 @@ int add_cea_modes(struct hdmi_edid_data *data, struct edid *edid)
 {
 	const u8 *cea = drm_find_cea_extension(edid);
 	const u8 *db, *hdmi = NULL, *video = NULL;
-	u8 dbl, hdmi_len, video_len = 0;
+	u8 dbl, hdmi_len = 0, video_len = 0;
 	int modes = 0;
 
 	if (cea && cea_revision(cea) >= 3) {

--- a/include/command.h
+++ b/include/command.h
@@ -139,7 +139,7 @@ enum command_ret_t {
  *			number of ticks the command took to complete.
  * @return 0 if the command succeeded, 1 if it failed
  */
-int cmd_process(int flag, int argc, char * const argv[],
+enum command_ret_t cmd_process(int flag, int argc, char * const argv[],
 			       int *repeatable, unsigned long *ticks);
 
 void fixup_cmdtable(cmd_tbl_t *cmdtp, int size);


### PR DESCRIPTION
Build log:
```
[🔨]   common/command.c:504:20: error: conflicting types for 'cmd_process' due to enum/integer mismatch; have 'enum command_ret_t(int,  int,  char * const*, int *, ulong *)' {aka 'enum command_ret_t(int,  int,  char * const*, int *, long unsigned int *)'} [-Werror=enum-int-mismatch]
[🔨]     504 | enum command_ret_t cmd_process(int flag, int argc, char * const argv[],
[🔨]         |                    ^~~~~~~~~~~
[🔨]   In file included from include/image.h:45,
[🔨]                    from include/common.h:39,
[🔨]                    from common/command.c:12:
[🔨]   include/command.h:142:5: note: previous declaration of 'cmd_process' with type 'int(int,  int,  char * const*, int *, long unsigned int *)'
[🔨]     142 | int cmd_process(int flag, int argc, char * const argv[],
[🔨]         |     ^~~~~~~~~~~
[🔨]   cc1: all warnings being treated as errors
[🔨]   make[1]: *** [scripts/Makefile.build:280: common/command.o] Error 1
[🔨]   make[1]: *** Waiting for unfinished jobs....
[🔨]     LD      lib/built-in.o
[🔨]     LD      drivers/usb/gadget/built-in.o
[🔨]   In function 'do_hdmi_vsdb_modes',
[🔨]       inlined from 'add_cea_modes' at common/edid.c:3617:12,
[🔨]       inlined from 'drm_add_edid_modes' at common/edid.c:5542:15:
[🔨]   common/edid.c:2934:17: error: 'hdmi_len' may be used uninitialized [-Werror=maybe-uninitialized]
[🔨]    2934 |         if (len < (8 + offset + 2))
[🔨]         |             ~~~~^~~~~~~~~~~~~~~~~~
[🔨]   common/edid.c: In function 'drm_add_edid_modes':
[🔨]   common/edid.c:3582:17: note: 'hdmi_len' was declared here
[🔨]    3582 |         u8 dbl, hdmi_len, video_len = 0;
[🔨]         |                 ^~~~~~~~
[🔨]   cc1: all warnings being treated as errors
```

```
[🔨]   common/command.c:504:20: error: conflicting types for 'cmd_process' due to enum/integer mismatch; have 'enum command_ret_t(int,  int,  char * const*, int *, ulong *)' {aka 'enum command_ret_t(int,  int,  char * const*, int *, long unsigned int *)'} [-Werror=enum-int-mismatch]
[🔨]     504 | enum command_ret_t cmd_process(int flag, int argc, char * const argv[],
[🔨]         |                    ^~~~~~~~~~~
[🔨]   In file included from include/image.h:45,
[🔨]                    from include/common.h:39,
[🔨]                    from common/command.c:12:
[🔨]   include/command.h:142:5: note: previous declaration of 'cmd_process' with type 'int(int,  int,  char * const*, int *, long unsigned int *)'
[🔨]     142 | int cmd_process(int flag, int argc, char * const argv[],
[🔨]         |     ^~~~~~~~~~~
[🔨]   cc1: all warnings being treated as errors
```
This two commit will fix them.