### PR TITLE
board: rockchip: evb_rk3528: Add hardware ID recognition for mEdge-RK3528A IO

### DIFF
--- a/board/rockchip/evb_rk3528/evb_rk3528.c
+++ b/board/rockchip/evb_rk3528/evb_rk3528.c
@@ -105,6 +105,7 @@ int board_usb_cleanup(int index, enum usb_init_type init)
 static struct variant_def variants[] = {
 	{"radxa,rock-2a",   80, 250, 0, -1, "rockchip/rk3528-rock-2a.dtb"},
 	{"radxa,rock-2a",   320, 380, 0, -1, "rockchip/rk3528-radxa-e20c.dtb"},
+	{"radxa,rock-2a",   430, 490, 0, -1, "rockchip/rk3528-medge-io.dtb"},
 	{"radxa,rock-2a",   530, 710, 0, -1, "rockchip/rk3528-rock-2f.dtb"},
 };
 


### PR DESCRIPTION
board: rockchip: evb_rk3528: Add hardware ID recognition for mEdge-RK3528A IO

Signed-off-by: SongJun Li <lisongjun@radxa.com>