### PR TITLE
cmd: add support for prompt=0 & timeout=0

### DIFF
--- a/cmd/pxe.c
+++ b/cmd/pxe.c
@@ -1463,7 +1463,10 @@ static int parse_pxefile_top(cmd_tbl_t *cmdtp, char *p, unsigned long base,
 			break;
 
 		case T_PROMPT:
-			eol_or_eof(&p);
+			err = parse_integer(&p, &cfg->prompt);
+			// Do not fail if prompt configuration is undefined
+			if (err <  0)
+				eol_or_eof(&p);
 			break;
 
 		case T_EOL:


### PR DESCRIPTION
Setting prompt=0 & timeout=0 in extlinux.conf will skip the user selection and boot the default kernel directly.

Based on https://source.denx.de/u-boot/u-boot/-/commit/739e8361f3fe78038251216df6096a32bc2d5839
Author:  Manuel Traut <manuel.traut@mt.com>