### PR TITLE
radxa-e25: blue light on when entering loader mode

### DIFF
--- a/arch/arm/dts/rk3568-radxa-e25.dts
+++ b/arch/arm/dts/rk3568-radxa-e25.dts
@@ -37,4 +37,20 @@
 			press-threshold-microvolt = <9>;
 		};
 	};
+
+	leds {
+		u-boot,dm-pre-reloc;
+		compatible = "gpio-leds";
+		status = "okay";
+
+		blue-led {
+			u-boot,dm-pre-reloc;
+			label = "blue";
+			gpios = <&gpio4 RK_PC5 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&gpio4 {
+	u-boot,dm-pre-reloc;
 };

--- a/arch/arm/mach-rockchip/boot_rkimg.c
+++ b/arch/arm/mach-rockchip/boot_rkimg.c
@@ -338,6 +338,9 @@ void setup_download_mode(void)
 			!run_command("test -e mmc 0:3 /boot/extlinux/extlinux.conf", 0)) {
 			printf("\nForce to boot from eMMC!\n");
 			run_command("sysboot mmc 0:3 any 0x00500000 /boot/extlinux/extlinux.conf", 0);
+		} else if ((fdt_node_offset_by_compatible(blob, -1, "radxa,e25")) >= 0) {
+			printf("\nTurn on Blue LED on Radxa E25!\n");
+			run_command("led blue on", 0);
 		}
 
 #ifdef CONFIG_CMD_ROCKUSB


### PR DESCRIPTION
Setting the state of the lamp via the gpio command When the recovery button is pressed to enter loader mode, the rgb led displays blue color.the blue light should be always on.

The number of the gpio pin that controls the rgb_blue lamp is 149 --> GPIO4_C5
The number of the gpio pin that controls the rgb_green lamp is 17 --> GPIO0_C1