### PR TITLE
dts: radxa-e25: add gpio3 and gpio4

### DIFF
--- a/arch/arm/dts/rk3568-radxa-e25.dts
+++ b/arch/arm/dts/rk3568-radxa-e25.dts
@@ -38,3 +38,11 @@
 		};
 	};
 };
+
+&gpio3 {
+	u-boot,dm-pre-reloc;
+};
+
+&gpio4 {
+	u-boot,dm-pre-reloc;
+};


### PR DESCRIPTION
To control the rgb_blue light you need to use gpio4. 
To use gpio4 properly need to turn on gpio3.