### PR TITLE
backport: mtd: spi-nor-ids: Add Winbond W25Q128JW ID

### DIFF
--- a/drivers/mtd/spi/spi-nor-ids.c
+++ b/drivers/mtd/spi/spi-nor-ids.c
@@ -462,6 +462,11 @@ const struct flash_info spi_nor_ids[] = {
 			SPI_NOR_HAS_LOCK | SPI_NOR_HAS_TB)
 	},
 	{
+		INFO("w25q128jw", 0xef8018, 0, 64 * 1024, 256,
+			SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ |
+			SPI_NOR_HAS_LOCK | SPI_NOR_HAS_TB)
+	},
+	{
 		INFO("w25q256fw", 0xef6019, 0, 64 * 1024, 512,
 			SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ |
 			SPI_NOR_HAS_LOCK | SPI_NOR_HAS_TB)


### PR DESCRIPTION
Some  Rock 3A have different SPI flash chip which broke u-boot on spi (only spl was loading which couldn't read spi and started core u-boot from sd-card if found) this backport enable support for this chip so that u-boot on spi + nvme boot is working again

Add ID for Winbond W25Q128JW device. This is a 128 Mbit QSPI NOR. Tested on W25Q128JWPIM part.


Cc: Horatiu Vultur <horatiu.vultur@microchip.com>
Cc: Simon Goldschmidt <simon.k.r.goldschmidt@gmail.com>
Cc: Stefan Roese <sr@denx.de>
Cc: Vignesh R <vigneshr@ti.com>
Reviewed-by: Stefan Roese <sr@denx.de>
Reviewed-by: Jagan Teki <jagan@amarulasolutions.com>