### PR TITLE
enable m.2 e-key pcie

### DIFF
--- a/arch/arm/dts/rk3568-rock-3a.dts
+++ b/arch/arm/dts/rk3568-rock-3a.dts
@@ -424,6 +424,19 @@
 	};
 };
 
+&combphy2_psq {
+        u-boot,dm-pre-reloc;
+        status = "okay";
+};
+
+&pcie2x1 {
+        u-boot,dm-pre-reloc;
+        vpcie3v3-supply = <&vcc3v3_pcie>;
+        pinctrl-0 = <&pcie20m1_pins>;
+        reset-gpios = <&gpio3 RK_PC1 GPIO_ACTIVE_HIGH>;
+        status = "okay";
+};
+
 &pcie30_phy_grf {
 	u-boot,dm-pre-reloc;
 };


### PR DESCRIPTION
enable m.2 e-key pcie so that boot with radxa m.2 e-key  extension is possible