### PR TITLE
rockchip: rk3588: Increase the MMU600PHP QOS to 4 for USB3_2

### DIFF
--- a/arch/arm/mach-rockchip/rk3588/rk3588.c
+++ b/arch/arm/mach-rockchip/rk3588/rk3588.c
@@ -17,6 +17,11 @@
 
 DECLARE_GLOBAL_DATA_PTR;
 
+/* QOS MMU600PHP-USB3_2 & SATA0-2 & GMAC0-1 */
+#define QOS_MMU600PHP_TBU_BASE		0xfdf3a608
+#define QOS_MMU600PHP_TCU_BASE		0xfdf3a808
+#define QOS_PRIORITY_LEVEL(h, l)	((((h) & 7) << 8) | ((l) & 7))
+
 #define FIREWALL_DDR_BASE		0xfe030000
 #define FW_DDR_MST5_REG			0x54
 #define FW_DDR_MST13_REG		0x74
@@ -1061,6 +1066,10 @@ int arch_cpu_init(void)
 
 	/* Select usb otg0 phy status to 0 that make rockusb can work at high-speed */
 	writel(0x00080008, USBGRF_BASE + USB_GRF_USB3OTG0_CON1);
+
+	/* Increase MMU600PHP QOS from 0 to 4 */
+	writel(QOS_PRIORITY_LEVEL(4, 4), QOS_MMU600PHP_TBU_BASE);
+	writel(QOS_PRIORITY_LEVEL(4, 4), QOS_MMU600PHP_TCU_BASE);
 
 	return 0;
 }

--- a/arch/arm/mach-rockchip/rk3588/rk3588.c
+++ b/arch/arm/mach-rockchip/rk3588/rk3588.c
@@ -1047,6 +1047,9 @@ int arch_cpu_init(void)
 	secure_reg &= 0xffff0000;
 	writel(secure_reg, FIREWALL_SYSMEM_BASE + FW_SYSM_MST27_REG);
 #else /* U-Boot */
+	/* Increase MMU600PHP QOS from 0 to 4 */
+	writel(QOS_PRIORITY_LEVEL(4, 4), QOS_MMU600PHP_TBU_BASE);
+	writel(QOS_PRIORITY_LEVEL(4, 4), QOS_MMU600PHP_TCU_BASE);
 	/* uboot: config iomux */
 #ifdef CONFIG_ROCKCHIP_EMMC_IOMUX
 	/* Set emmc iomux for good extention if the emmc is not the boot device */
@@ -1066,10 +1069,6 @@ int arch_cpu_init(void)
 
 	/* Select usb otg0 phy status to 0 that make rockusb can work at high-speed */
 	writel(0x00080008, USBGRF_BASE + USB_GRF_USB3OTG0_CON1);
-
-	/* Increase MMU600PHP QOS from 0 to 4 */
-	writel(QOS_PRIORITY_LEVEL(4, 4), QOS_MMU600PHP_TBU_BASE);
-	writel(QOS_PRIORITY_LEVEL(4, 4), QOS_MMU600PHP_TCU_BASE);
 
 	return 0;
 }


### PR DESCRIPTION
This patch increases the MMU600PHP QOS from default 0 to 4 to get better transmission performance for USB3_2 & SATA0-2 & GMAC0-1.


Change-Id: I3a51483e41310c2abbca93a6a9c6e51d5ce50841