### PR TITLE
dm: regulator: the always-on regulator should never be disabled

### DIFF
--- a/drivers/power/regulator/regulator-uclass.c
+++ b/drivers/power/regulator/regulator-uclass.c
@@ -148,9 +148,16 @@ int regulator_get_enable(struct udevice *dev)
 int regulator_set_enable(struct udevice *dev, bool enable)
 {
 	const struct dm_regulator_ops *ops = dev_get_driver_ops(dev);
+	struct dm_regulator_uclass_platdata *uc_pdata;
 
 	if (!ops || !ops->set_enable)
 		return -ENOSYS;
+
+	uc_pdata = dev_get_uclass_platdata(dev);
+	if (!enable && uc_pdata->always_on) {
+		printf("the always on regulator (%s) should never be disabled!\n", dev->name);
+		return -EACCES;
+	}
 
 	return ops->set_enable(dev, enable);
 }


### PR DESCRIPTION
If the regulator is an always on regulator, we don't need to do work for disable calls.

Change-Id: Ie6a9181abd249abd8559d7c9b0ff93eaa5f3b9bc