### PR TITLE
Revert "rockchip: dts: rk3588: emmc: enable HS400ES support"

### DIFF
--- a/arch/arm/dts/rk3588-u-boot.dtsi
+++ b/arch/arm/dts/rk3588-u-boot.dtsi
@@ -178,8 +178,7 @@
 &sdhci {
 	bus-width = <8>;
 	u-boot,dm-spl;
-	mmc-hs400-1_8v;
-	mmc-hs400-enhanced-strobe;
+	mmc-hs200-1_8v;
 	non-removable;
 	status = "okay";
 };


### PR DESCRIPTION
This reverts commit cf4516d636036b8c13a20bee8f7def6ff97c0371.

Improve eMMC module compatibility, test with FORESEE eMMC module 128GB