### PR TITLE
rockchip: allow passing of BL32 location via variable TEE

### DIFF
--- a/arch/arm/mach-rockchip/fit_nodes.sh
+++ b/arch/arm/mach-rockchip/fit_nodes.sh
@@ -180,7 +180,7 @@ function gen_bl32_node()
 		fi
 	fi
 
-	TEE="tee.bin"
+	TEE="${TEE:=tee.bin}"
 	echo "		optee {
 			description = \"OP-TEE\";
 			data = /incbin/(\"${TEE}${SUFFIX}\");


### PR DESCRIPTION
Armbian is using env TEE to set BL32 blob file for rk3576:
https://github.com/armbian/build/blob/main/config/boards/armsom-sige5.csc#L20