### PR TITLE
rockchip: rkimg: fix accidentally skipping adc-keys detection

### DIFF
--- a/arch/arm/mach-rockchip/boot_rkimg.c
+++ b/arch/arm/mach-rockchip/boot_rkimg.c
@@ -300,8 +300,9 @@ __weak int rockchip_dnl_key_pressed(void)
 {
 #if defined(CONFIG_DM_KEY)
 	return key_is_pressed(key_read(KEY_VOLUMEUP));
+#endif
 
-#elif defined(CONFIG_ADC)
+#if defined(CONFIG_ADC)
 	const void *blob = gd->fdt_blob;
 	int node, ret, channel = 1;
 	u32 val, chns[2];


### PR DESCRIPTION
When CONFIG_DM_KEY is defined, adc-keys detection will be skipped, their logic is not mutually exclusive, so change #elif to #if