### PR TITLE
rockchip: dts: rk3566: add basic dtsi

### DIFF
--- a/arch/arm/dts/rk3566-radxa-cm3.dtsi
+++ b/arch/arm/dts/rk3566-radxa-cm3.dtsi
@@ -6,7 +6,7 @@
  */
 
 /dts-v1/;
-#include "rk3568.dtsi"
+#include "rk3566.dtsi"
 #include "rk3568-u-boot.dtsi"
 #include <dt-bindings/input/input.h>
 

--- a/arch/arm/dts/rk3566-radxa-zero3.dts
+++ b/arch/arm/dts/rk3566-radxa-zero3.dts
@@ -5,7 +5,7 @@
  */
 
 /dts-v1/;
-#include "rk3568.dtsi"
+#include "rk3566.dtsi"
 #include "rk3568-u-boot.dtsi"
 #include <dt-bindings/input/input.h>
 

--- a/arch/arm/dts/rk3566-rock-3c.dts
+++ b/arch/arm/dts/rk3566-rock-3c.dts
@@ -5,7 +5,7 @@
  */
 
 /dts-v1/;
-#include "rk3568.dtsi"
+#include "rk3566.dtsi"
 #include "rk3568-u-boot.dtsi"
 #include <dt-bindings/input/input.h>
 

--- a/arch/arm/dts/rk3566.dtsi
+++ b/arch/arm/dts/rk3566.dtsi
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * Copyright (c) 2023 Rockchip Electronics Co., Ltd.
+ */
+
+#include "rk3568.dtsi"
+
+/ {
+	compatible = "rockchip,rk3566";
+};
+
+&power {
+	pd_pipe@RK3568_PD_PIPE {
+		reg = <RK3568_PD_PIPE>;
+		clocks = <&cru PCLK_PIPE>;
+		pm_qos = <&qos_pcie2x1>,
+			 <&qos_sata1>,
+			 <&qos_sata2>,
+			 <&qos_usb3_0>,
+			 <&qos_usb3_1>;
+		#power-domain-cells = <0>;
+	};
+};
+
+&usbdrd_dwc3 {
+	phys = <&u2phy0_otg>;
+	phy-names = "usb2-phy";
+	extcon = <&usb2phy0>;
+	maximum-speed = "high-speed";
+};


### PR DESCRIPTION
主要修复zero3 usb device mode，host 端不识别