### PR TITLE
Add Booting Android/Buildroot/Yoto systems

### DIFF
--- a/arch/arm/mach-rockchip/boot_mode.c
+++ b/arch/arm/mach-rockchip/boot_mode.c
@@ -9,6 +9,7 @@
 #include <malloc.h>
 #include <asm/io.h>
 #include <asm/arch/boot_mode.h>
+#include <android_bootloader.h>
 
 DECLARE_GLOBAL_DATA_PTR;
 
@@ -25,7 +26,7 @@ static int misc_require_recovery(u32 bcb_offset, int *bcb_recovery_msg)
 	disk_partition_t part;
 	int cnt, recovery = 0;
 
-	dev_desc = rockchip_get_bootdev();
+	dev_desc = android_get_bootdev();
 	if (!dev_desc) {
 		printf("dev_desc is NULL!\n");
 		goto out;

--- a/arch/arm/mach-rockchip/fit.c
+++ b/arch/arm/mach-rockchip/fit.c
@@ -10,6 +10,7 @@
 #include <sysmem.h>
 #include <asm/arch/fit.h>
 #include <asm/arch/resource_img.h>
+#include <android_bootloader.h>
 
 DECLARE_GLOBAL_DATA_PTR;
 
@@ -399,7 +400,7 @@ void *fit_image_load_bootables(ulong *size)
 	int blk_num;
 	void *fit;
 
-	dev_desc = rockchip_get_bootdev();
+	dev_desc = android_get_bootdev();
 	if (!dev_desc)
 		return NULL;
 

--- a/arch/arm/mach-rockchip/resource_img.c
+++ b/arch/arm/mach-rockchip/resource_img.c
@@ -14,6 +14,7 @@
 #include <asm/arch/rk_hwid.h>
 #include <asm/arch/uimage.h>
 #include <asm/arch/fit.h>
+#include <android_bootloader.h>
 
 DECLARE_GLOBAL_DATA_PTR;
 
@@ -361,7 +362,7 @@ static int resource_default(struct blk_desc *desc,
 
 static int resource_scan(void)
 {
-	struct blk_desc *desc = rockchip_get_bootdev();
+	struct blk_desc *desc = android_get_bootdev();
 	__maybe_unused int ret;
 
 	if (!desc) {
@@ -430,7 +431,7 @@ static struct resource_file *resource_get_file(const char *name)
 
 int rockchip_read_resource_file(void *buf, const char *name, int blk_offset, int len)
 {
-	struct blk_desc *desc = rockchip_get_bootdev();
+	struct blk_desc *desc = android_get_bootdev();
 	struct resource_file *f;
 	int blk_cnt;
 	ulong pos;

--- a/arch/arm/mach-rockchip/rk3576/rk3576.c
+++ b/arch/arm/mach-rockchip/rk3576/rk3576.c
@@ -19,6 +19,7 @@
 #include <asm/arch/ioc_rk3576.h>
 #include <asm/arch/rockchip_smccc.h>
 #include <asm/system.h>
+#include <android_bootloader.h>
 
 DECLARE_GLOBAL_DATA_PTR;
 
@@ -419,7 +420,7 @@ int arch_cpu_init(void)
 #if defined(CONFIG_SCSI) && defined(CONFIG_CMD_SCSI) && defined(CONFIG_UFS)
 int rk_board_dm_fdt_fixup(const void *blob)
 {
-	struct blk_desc *desc = rockchip_get_bootdev();
+	struct blk_desc *desc = android_get_bootdev();
 	const char *status = NULL;
 	int node = -1;
 

--- a/arch/arm/mach-rockchip/vendor.c
+++ b/arch/arm/mach-rockchip/vendor.c
@@ -12,6 +12,7 @@
 #include <part.h>
 #include <fdt_support.h>
 #include <usbplug.h>
+#include <android_bootloader.h>
 
 /* tag for vendor check */
 #define VENDOR_TAG		0x524B5644
@@ -317,7 +318,7 @@ static int vendor_ops(u8 *buffer, u32 addr, u32 n_sec, int write)
 	unsigned int lba = 0;
 	int ret = 0;
 
-	dev_desc = rockchip_get_bootdev();
+	dev_desc = android_get_bootdev();
 	if (!dev_desc) {
 		printf("%s: dev_desc is NULL!\n", __func__);
 		return -ENODEV;
@@ -435,7 +436,7 @@ int vendor_storage_init(void)
 	u16 version2_offset, part_size;
 	struct blk_desc *dev_desc;
 
-	dev_desc = rockchip_get_bootdev();
+	dev_desc = android_get_bootdev();
 	if (!dev_desc) {
 		printf("[Vendor ERROR]:Invalid boot device type(%d)\n",
 		       bootdev_type);

--- a/common/android_bootloader.c
+++ b/common/android_bootloader.c
@@ -30,6 +30,12 @@
 #include <console.h>
 #include <sysmem.h>
 
+struct blk_desc *android_dev_desc = NULL;
+
+struct blk_desc *android_get_bootdev(void) {
+    return android_dev_desc;
+}
+
 DECLARE_GLOBAL_DATA_PTR;
 
 int android_bootloader_message_load(
@@ -133,7 +139,7 @@ int android_bcb_write(char *cmd)
 	if (strlen(cmd) >= 32)
 		return -ENOMEM;
 
-	dev_desc = rockchip_get_bootdev();
+	dev_desc = android_get_bootdev();
 	if (!dev_desc) {
 		printf("%s: dev_desc is NULL!\n", __func__);
 		return -ENODEV;
@@ -196,7 +202,7 @@ static int android_bootloader_get_fdt(const char *part_name,
 	int part_num = -1;
 	int ret;
 
-	dev_desc = rockchip_get_bootdev();
+	dev_desc = android_get_bootdev();
 	if (!dev_desc) {
 		printf("%s: dev_desc is NULL!\n", __func__);
 		return -1;
@@ -771,7 +777,7 @@ static AvbSlotVerifyResult android_slot_verify(char *boot_partname,
 	unsigned long load_address = *android_load_address;
 	int ret;
 
-	dev_desc = rockchip_get_bootdev();
+	dev_desc = android_get_bootdev();
 	if (!dev_desc)
 		return AVB_IO_RESULT_ERROR_IO;
 
@@ -1005,7 +1011,7 @@ static int android_get_dtbo(ulong *fdt_dtbo,
 	int ret;
 
 	/* Get partition info */
-	dev_desc = rockchip_get_bootdev();
+	dev_desc = android_get_bootdev();
 	if (!dev_desc)
 		return -ENODEV;
 
@@ -1113,7 +1119,7 @@ int android_fdt_overlay_apply(void *fdt_addr)
 #endif
 	}
 
-	dev_desc = rockchip_get_bootdev();
+	dev_desc = android_get_bootdev();
 	if (!dev_desc)
 		return -ENODEV;
 
@@ -1225,6 +1231,8 @@ int android_bootloader_boot_flow(struct blk_desc *dev_desc,
 	char slot_suffix[3] = {0};
 	const char *mode_cmdline = NULL;
 	char *boot_partname = ANDROID_PARTITION_BOOT;
+
+	android_dev_desc = dev_desc;
 
 	/*
 	 * 1. Load MISC partition and determine the boot mode
@@ -1406,7 +1414,7 @@ int android_avb_boot_flow(unsigned long kernel_address)
 	disk_partition_t boot_part_info;
 	int ret;
 
-	dev_desc = rockchip_get_bootdev();
+	dev_desc = android_get_bootdev();
 	if (!dev_desc) {
 		printf("%s: dev_desc is NULL!\n", __func__);
 		return -1;
@@ -1439,7 +1447,7 @@ int android_boot_flow(unsigned long kernel_address)
 	disk_partition_t boot_part_info;
 	int ret;
 
-	dev_desc = rockchip_get_bootdev();
+	dev_desc = android_get_bootdev();
 	if (!dev_desc) {
 		printf("%s: dev_desc is NULL!\n", __func__);
 		return -1;

--- a/common/image-android.c
+++ b/common/image-android.c
@@ -25,6 +25,7 @@
 #include <android_avb/rk_avb_ops_user.h>
 #endif
 #include <optee_include/OpteeClientInterface.h>
+#include <android_bootloader.h>
 
 DECLARE_GLOBAL_DATA_PTR;
 
@@ -46,7 +47,7 @@ static int android_version_init(void)
 	disk_partition_t part;
 	int os_version;
 
-	desc = rockchip_get_bootdev();
+	desc = android_get_bootdev();
 	if (!desc) {
 		printf("No bootdev\n");
 		return -1;
@@ -424,7 +425,7 @@ static sha1_context sha1_ctx;
 static int image_load(img_t img, struct andr_img_hdr *hdr,
 		      ulong blkstart, void *ram_base)
 {
-	struct blk_desc *desc = rockchip_get_bootdev();
+	struct blk_desc *desc = android_get_bootdev();
 	disk_partition_t part_vendor_boot;
 	disk_partition_t part_init_boot;
 	__maybe_unused u32 typesz;

--- a/include/android_bootloader.h
+++ b/include/android_bootloader.h
@@ -9,6 +9,8 @@
 
 #include <common.h>
 
+extern struct blk_desc *android_dev_desc;
+
 enum android_boot_mode {
 	ANDROID_BOOT_MODE_NORMAL = 0,
 
@@ -26,6 +28,11 @@ enum android_boot_mode {
 	 */
 	ANDROID_BOOT_MODE_BOOTLOADER,
 };
+
+/** android_get_bootdev- Get the devtype passed by bootcmd.
+ *
+ */
+struct blk_desc *android_get_bootdev(void);
 
 /** android_bootloader_boot_flow - Execute the Android Bootloader Flow.
  * Performs the Android Bootloader boot flow, loading the appropriate Android

--- a/include/config_distro_bootcmd.h
+++ b/include/config_distro_bootcmd.h
@@ -397,6 +397,7 @@
 	"scan_dev_for_boot_part="                                         \
 		"part list ${devtype} ${devnum} -bootable devplist; "     \
 		"env exists devplist || setenv devplist 1; "              \
+		"boot_android ${devtype} ${devnum}; "                      \
 		"for distro_bootpart in ${devplist}; do "                 \
 			"if fstype ${devtype} "                           \
 					"${devnum}:${distro_bootpart} "   \

--- a/include/configs/rockchip-common.h
+++ b/include/configs/rockchip-common.h
@@ -203,11 +203,10 @@
 #define RKIMG_BOOTCOMMAND			\
 	"boot_fit;"
 #else
-#define RKIMG_BOOTCOMMAND			\
-	"run distro_bootcmd;"			\
-	"boot_android ${devtype} ${devnum};"	\
-	"boot_fit;"				\
-	"bootrkp;"
+#define RKIMG_BOOTCOMMAND           \
+	"run distro_bootcmd; " \
+	"boot_fit; " \
+	"bootrkp;
 #endif
 
 #endif /* CONFIG_SPL_BUILD */

--- a/lib/avb/libavb_user/avb_ops_user.c
+++ b/lib/avb/libavb_user/avb_ops_user.c
@@ -42,6 +42,7 @@
 #include <android_avb/avb_vbmeta_image.h>
 #include <android_avb/avb_atx_validate.h>
 #include <boot_rkimg.h>
+#include <android_bootloader.h>
 
 static void byte_to_block(int64_t *offset,
 			  size_t *num_bytes,
@@ -75,7 +76,7 @@ static AvbIOResult get_size_of_partition(AvbOps *ops,
 	struct blk_desc *dev_desc;
 	disk_partition_t part_info;
 
-	dev_desc = rockchip_get_bootdev();
+	dev_desc = android_get_bootdev();
 	if (!dev_desc) {
 		printf("%s: Could not find device\n", __func__);
 		return AVB_IO_RESULT_ERROR_NO_SUCH_PARTITION;
@@ -111,7 +112,7 @@ static AvbIOResult read_from_partition(AvbOps *ops,
 	}
 
 	byte_to_block(&offset, &num_bytes, &offset_blk, &blkcnt);
-	dev_desc = rockchip_get_bootdev();
+	dev_desc = android_get_bootdev();
 	if (!dev_desc) {
 		printf("%s: Could not find device\n", __func__);
 		return AVB_IO_RESULT_ERROR_NO_SUCH_PARTITION;
@@ -162,7 +163,7 @@ static AvbIOResult write_to_partition(AvbOps *ops,
 		return AVB_IO_RESULT_ERROR_OOM;
 	}
 	memset(buffer_temp, 0, 512 * blkcnt);
-	dev_desc = rockchip_get_bootdev();
+	dev_desc = android_get_bootdev();
 	if (!dev_desc) {
 		printf("%s: Could not find device\n", __func__);
 		return AVB_IO_RESULT_ERROR_NO_SUCH_PARTITION;
@@ -349,7 +350,7 @@ static AvbIOResult get_unique_guid_for_partition(AvbOps *ops,
 	struct blk_desc *dev_desc;
 	disk_partition_t part_info;
 
-	dev_desc = rockchip_get_bootdev();
+	dev_desc = android_get_bootdev();
 	if (!dev_desc) {
 		printf("%s: Could not find device\n", __func__);
 		return AVB_IO_RESULT_ERROR_NO_SUCH_PARTITION;
@@ -446,7 +447,7 @@ static AvbIOResult get_preloaded_partition(AvbOps* ops,
 	AvbIOResult ret;
 	int full_preload = 0;
 
-	dev_desc = rockchip_get_bootdev();
+	dev_desc = android_get_bootdev();
 	if (!dev_desc)
 		return AVB_IO_RESULT_ERROR_IO;
 

--- a/lib/avb/rk_avb_user/rk_avb_ops_user.c
+++ b/lib/avb/rk_avb_user/rk_avb_ops_user.c
@@ -26,6 +26,7 @@
 #include <boot_rkimg.h>
 #include <u-boot/sha256.h>
 #include <asm/arch/rk_atags.h>
+#include <android_bootloader.h>
 
 /* rk used */
 int rk_avb_get_pub_key(struct rk_pub_key *pub_key)
@@ -571,7 +572,7 @@ int rk_avb_get_part_has_slot_info(const char *base_name)
 	struct blk_desc *dev_desc;
 	const char *slot_suffix = "_a";
 
-	dev_desc = rockchip_get_bootdev();
+	dev_desc = android_get_bootdev();
 	if (!dev_desc) {
 		printf("%s: Could not find device!\n", __func__);
 		return -1;


### PR DESCRIPTION
Rock4d spinor now supports booting NVME and UFS. There's a priority order: SD card has the highest priority, followed by NVME and UFS. Android NVME > Android UFS > Linux NVME > Linux UFS.