### PR TITLE
fix(ufs): correct initialization logic in sunxi_ufs driver

### DIFF
--- a/cmd/sunxi_flash.c
+++ b/cmd/sunxi_flash.c
@@ -361,7 +361,7 @@ U_BOOT_CMD(sunxi_flash, 6, 1, do_sunxi_flash, "sunxi_flash sub-system",
 
 #ifdef CONFIG_SUNXI_UFS
 
-extern int ufs_has_init;
+extern int ufs_init_successful;
 
 static int do_sunxi_flash_ufs(cmd_tbl_t *cmdtp, int flag, int argc, char * const argv[])
 {
@@ -376,15 +376,14 @@ static int do_sunxi_flash_ufs(cmd_tbl_t *cmdtp, int flag, int argc, char * const
         return -1;
     }
 
-	printf("ufs0 has init\n");
-    return (ufs_has_init == 1) ? 0 : -1;
+	return ufs_init_successful ? 0 : -1;
 }
 
 U_BOOT_CMD(
     sunxi_flash_ufs, 3, 1, do_sunxi_flash_ufs,
     "check sunxi UFS state; only dev 0 is valid",
     "dev <n>\n"
-    "  dev 0 : return 0 if UFS inited (ufs_has_init==1), else -1\n"
+    "return 0 for successful UFS initialization, -1 otherwise.\n"
 );
 #else  /* !CONFIG_SUNXI_UFS */
 

--- a/drivers/sunxi_flash/ufs/sunxi_ufs.c
+++ b/drivers/sunxi_flash/ufs/sunxi_ufs.c
@@ -44,6 +44,7 @@ s32 sunxi_ufs_global_logical_unit_config(void);
 u64 sunxi_ufs_global_update_ufs_size(void);
 
 int  ufs_has_init;
+bool ufs_init_successful;
 static int sunxi_flash_ufs_init(int stage, int card_no);
 int sunxi_ufs_init_for_sprite(int workmode, int card_no);
 int sunxi_ufs_init_for_boot(int workmode, int card_no);
@@ -79,6 +80,8 @@ static unsigned char _inner_buffer[4096 + 64]; /*align temp buffer*/
 
 int sunxi_flash_ufs_probe(void)
 {
+	ufs_has_init = 0;
+	ufs_init_successful = false;
 	return 0;
 }
 
@@ -1239,16 +1242,18 @@ int sunxi_ufs_init_for_boot(int workmode, int card_no)
 	if (!ufs_has_init) {
 		ufs_has_init = 1;
 		ret = sunxi_ufs_global_init();
+		if (ret) {
+			ufs_init_successful = false;
+			puts("fail to init ufs\n");
+			return -1;
+		}
+		ufs_init_successful = true;
+		debug("ufs %d init successful\n", card_no);
 	} else {
 		puts("ufs has init\n");
 		return 0;
 	}
 
-	if (ret) {
-		printf("fail to init ufs\n");
-		return -1;
-	}
-	debug("ufs %d init ok\n", card_no);
 	return 0;
 }
 


### PR DESCRIPTION
Fix the issue where U-Boot process gets stuck due to incorrect initialization flow when the UFS module is not present.