### PR TITLE
arm: dts: rock-4c-plus: fix vcc5v0_host power settings

### DIFF
--- a/arch/arm/dts/rk3399-rock-4c-plus.dts
+++ b/arch/arm/dts/rk3399-rock-4c-plus.dts
@@ -52,7 +52,7 @@
 		pinctrl-names = "default";
 		pinctrl-0 = <&vcc5v0_host_en>;
 		regulator-name = "vcc5v0_host";
-		vin-supply = <&vcc5v0_sys>;
+		vin-supply = <&vcc5v0_usb2>;
 	};
 
 	clkin_gmac: external-gmac-clock {
@@ -443,6 +443,7 @@
 			};
 
 			vcc5v0_usb2: SWITCH_REG1 {
+				regulator-always-on;
 				regulator-min-microvolt = <5000000>;
 				regulator-max-microvolt = <5000000>;
 


### PR DESCRIPTION
1. Set vcc5v0_host vin-supply to vcc5v0_usb2 [1].
2. Set vcc5v0_usb2 always-on

To fix usb_boot.

[1] https://dl.radxa.com/rockpi4/docs/hw/rockpi4/rockpi4c_plus_v12_sch_220304.pdf