### PR TITLE
Fix USB3 ports issue and add startup logo

### DIFF
--- a/board/sunxi/board_common.c
+++ b/board/sunxi/board_common.c
@@ -900,6 +900,10 @@ void board_quiesce_devices(void)
 #ifdef CONFIG_SUNXI_DMA
 	sunxi_dma_exit();
 #endif
+#ifdef CONFIG_PCI
+	extern void sunxi_pcie_exit(void);
+	sunxi_pcie_exit();
+#endif
 }
 
 void sunxi_board_close_source(void)

--- a/drivers/pci/pcie-sunxi-plat.c
+++ b/drivers/pci/pcie-sunxi-plat.c
@@ -371,12 +371,21 @@ static int sunxi_pcie_plat_combo_phy_init(struct sunxi_pcie *pci)
 	return 0;
 }
 
-#if 0
 static void sunxi_pcie_plat_combo_phy_deinit(struct sunxi_pcie *pci)
 {
 	generic_phy_exit(pci->phy);
 }
-#endif
+
+void sunxi_pcie_plat_hw_deinit(struct udevice *dev)
+{
+	struct sunxi_pcie *pci = dev_get_priv(dev);
+
+	sunxi_pcie_plat_combo_phy_deinit(pci);
+
+	sunxi_pcie_plat_power_off(pci);
+
+	sunxi_pcie_plat_clk_exit(pci);
+}
 
 int sunxi_pcie_plat_hw_init(struct udevice *dev)
 {

--- a/drivers/pci/pcie-sunxi.h
+++ b/drivers/pci/pcie-sunxi.h
@@ -456,6 +456,7 @@ struct sunxi_pcie {
 
 void sunxi_pcie_plat_init(struct udevice *dev);
 int sunxi_pcie_plat_hw_init(struct udevice *dev);
+void sunxi_pcie_plat_hw_deinit(struct udevice *dev);
 
 void sunxi_pcie_plat_set_rate(struct sunxi_pcie *pci);
 void sunxi_pcie_plat_set_mode(struct sunxi_pcie *pci);

--- a/drivers/pci/pcie_sunxi_rc.c
+++ b/drivers/pci/pcie_sunxi_rc.c
@@ -23,6 +23,9 @@
 
 DECLARE_GLOBAL_DATA_PTR;
 
+static struct udevice *g_udev;
+static bool pcie_had_probe;
+
 #define sunxi_pcie_DBG			0
 
 #define __pcie_dev_print_emit(fmt, ...) \
@@ -408,6 +411,7 @@ static int sunxi_pcie_probe(struct udevice *dev)
 	struct pci_controller *hose = dev_get_uclass_priv(ctlr);
 	int ret;
 
+	g_udev = dev;
 	pcie->first_busno = dev->seq;
 	pcie->dev = dev;
 	pcie->drvdata = (struct sunxi_pcie_of_data *)dev_get_driver_data(dev);
@@ -442,7 +446,15 @@ static int sunxi_pcie_probe(struct udevice *dev)
 	/* Start the controller. */
 	sunxi_pcie_host_init(dev);
 
+	pcie_had_probe = true;
+
 	return 0;
+}
+
+void sunxi_pcie_exit(void)
+{
+	if (pcie_had_probe)
+		sunxi_pcie_plat_hw_deinit(g_udev);
 }
 
 static const struct dm_pci_ops sunxi_pcie_ops = {

--- a/drivers/phy/allwinner/sunxi-inno-combophy.c
+++ b/drivers/phy/allwinner/sunxi-inno-combophy.c
@@ -119,6 +119,7 @@ struct sunxi_combphy {
 	struct regulator *select3v3_supply;
 	bool initialized;
 };
+static int pcie_usb3_sub_system_exit(struct sunxi_combphy *combphy);
 
 static void sunxi_combphy_usb3_phy_set(struct sunxi_combphy *combphy, bool enable)
 {
@@ -275,12 +276,12 @@ static int sunxi_combphy_usb3_init(struct sunxi_combphy *combphy)
 	return 0;
 }
 
-// static int sunxi_combphy_usb3_exit(struct sunxi_combphy *combphy)
-// {
-// 	sunxi_combphy_usb3_phy_set(combphy, false);
+static int sunxi_combphy_usb3_exit(struct sunxi_combphy *combphy)
+{
+	sunxi_combphy_usb3_phy_set(combphy, false);
 
-// 	return 0;
-// }
+	return 0;
+}
 
 static void sunxi_combphy_pcie_phy_enable(struct sunxi_combphy *combphy)
 {
@@ -415,6 +416,33 @@ static int sunxi_combphy_pcie_init(struct sunxi_combphy *combphy)
 	return 0;
 }
 
+static int sunxi_combphy_pcie_exit(struct sunxi_combphy *combphy)
+{
+	u32 val;
+
+	/* set the phy:
+	 * bit(17): aclk enable
+	 * bit(16): hclk enbale
+	 * bit(1) : pcie_presetn
+	 * bit(0) : pcie_power_up_rstn
+	 */
+	val = readl(combphy->phy_ctl + PCIE_COMBO_PHY_BGR);
+	val &= (~(0x03<<0));
+	val &= (~(0x03<<16));
+	writel(val, combphy->phy_ctl + PCIE_COMBO_PHY_BGR);
+
+	/* Assert the phy */
+	val = readl(combphy->phy_ctl + PCIE_COMBO_PHY_CTL);
+	val &= (~PHY_USE_SEL);
+	val &= (~(0x03<<8));
+	val &= (~PHY_RSTN);
+	writel(val, combphy->phy_ctl + PCIE_COMBO_PHY_CTL);
+
+	pcie_usb3_sub_system_exit(combphy);
+
+	return 0;
+}
+
 static int sunxi_combphy_set_mode(struct sunxi_combphy *combphy)
 {
 	switch (combphy->mode) {
@@ -448,6 +476,25 @@ static int sunxi_inno_phy_init(struct phy *phy)
 	}
 
 	return ret;
+}
+
+static int sunxi_combphy_exit(struct phy *phy)
+{
+	struct sunxi_combphy *combphy = dev_get_priv(phy->dev);
+
+	switch (combphy->mode) {
+	case PHY_TYPE_PCIE:
+		sunxi_combphy_pcie_exit(combphy);
+		break;
+	case PHY_TYPE_USB3:
+		sunxi_combphy_usb3_exit(combphy);
+		break;
+	default:
+		dev_err(combphy->dev, "incompatible PHY type\n");
+		return -EINVAL;
+	}
+
+	return 0;
 }
 
 /*  PCIE USB3 Sub-system Application */
@@ -536,6 +583,20 @@ static void pcie_usb3_sub_system_enable(struct sunxi_combphy *combphy)
 	combphy->vernum = combo_sysver_get(combphy);
 }
 
+static void pcie_usb3_sub_system_disable(struct sunxi_combphy *combphy)
+{
+	combo_phy_mode_set(combphy, false);
+
+	if (combphy->user == PHY_USE_BY_PCIE)
+		combo_pcie_clk_set(combphy, false);
+	else if (combphy->user == PHY_USE_BY_USB3)
+		combo_usb3_clk_set(combphy, false);
+	else if (combphy->user == PHY_USE_BY_PCIE_USB3_U2) {
+		combo_pcie_clk_set(combphy, false);
+		combo_usb3_clk_set(combphy, false);
+	}
+}
+
 static int pcie_usb3_sub_system_init(struct sunxi_combphy *combphy)
 {
 	unsigned long reg_value = 0;
@@ -561,6 +622,34 @@ static int pcie_usb3_sub_system_init(struct sunxi_combphy *combphy)
 	pcie_usb3_sub_system_enable(combphy);
 
 	combphy->initialized = true;
+
+	return 0;
+}
+
+static int pcie_usb3_sub_system_exit(struct sunxi_combphy *combphy)
+{
+	unsigned long reg_value = 0;
+	struct sunxi_ccm_reg *const ccm =
+		(struct sunxi_ccm_reg *)SUNXI_CCM_BASE;
+
+	if (!combphy->initialized)
+		return 0;
+
+	pcie_usb3_sub_system_disable(combphy);
+
+	//0xaac pcie_bgr_reg
+	reg_value = readl(&ccm->pcie_bgr_reg);
+	reg_value &= ~(1 << PCIE_BRG_REG_RST);
+	writel(reg_value, &ccm->pcie_bgr_reg);
+
+	//0xa84 usb2_ref_clk_reg
+	reg_value = readl(0x2001a84);
+	reg_value &= ~(0x1<<31);
+	reg_value &= ~(0x7<<24);
+	reg_value &= ~(0x1f<<0);
+	writel(reg_value, 0x2001a84);
+
+	combphy->initialized = false;
 
 	return 0;
 }
@@ -591,6 +680,7 @@ static const struct sunxi_combophy_of_data sunxi_inno_v1_of_data = {
 
 static const struct phy_ops sunxi_inno_phy_ops = {
 	.init		= sunxi_inno_phy_init,
+	.exit 		= sunxi_combphy_exit,
 };
 
 static const struct udevice_id sunxi_inno_phy_of_match_table[] = {

--- a/drivers/video/drm/sunxi_drm_drv.c
+++ b/drivers/video/drm/sunxi_drm_drv.c
@@ -822,7 +822,7 @@ static int load_bmp_logo(struct display_state *state, char *bmp_name)
 		state->logo = NULL;
 	}
 
-	state->logo = load_file(bmp_name, "bootloader");
+	state->logo = load_file(bmp_name, "primary");
 	if (!state->logo) {
 		state->logo = load_file(bmp_name, "boot-resource");
 	}


### PR DESCRIPTION
1. Fix the recognition issue of the USB3 port.
2. Modify the partition for reading the logo file.