### PR TITLE
pci: sunxi: fix DesignWare CFG0/CFG1 config access and RC bus numbering

### DIFF
--- a/drivers/pci/pcie_sunxi_rc.c
+++ b/drivers/pci/pcie_sunxi_rc.c
@@ -219,7 +219,7 @@ static void sunxi_pcie_host_setup_rc(struct sunxi_pcie_port *pp)
 	/* setup bus numbers */
 	val = sunxi_pcie_readl_dbi(pci, PCI_PRIMARY_BUS);
 	val &= 0xff000000;
-	val |= 0x00ff0100;
+	val |= PCIE_PRIMARY_BUS_ENABLE;
 	sunxi_pcie_writel_dbi(pci, PCI_PRIMARY_BUS, val);
 
 	/* setup command register */

--- a/drivers/pci/pcie_sunxi_rc.c
+++ b/drivers/pci/pcie_sunxi_rc.c
@@ -89,10 +89,11 @@ static int sunxi_pcie_rd_other_conf(struct sunxi_pcie_port *pp, pci_dev_t d, int
 {
 	int ret = PCIBIOS_SUCCESSFUL, type;
 	u64 busdev;
+	struct sunxi_pcie *pci = to_sunxi_pcie_from_pp(pp);
 
 	busdev = PCIE_ATU_BUS(PCI_BUS(d)) | PCIE_ATU_DEV(PCI_DEV(d)) | PCIE_ATU_FUNC(PCI_FUNC(d));
 
-	if (PCI_BUS(d) != 0)
+	if (PCI_BUS(d) == pci->first_busno + 1)
 		type = PCIE_ATU_TYPE_CFG0;
 	else
 		type = PCIE_ATU_TYPE_CFG1;
@@ -108,10 +109,11 @@ static int sunxi_pcie_wr_other_conf(struct sunxi_pcie_port *pp, pci_dev_t d, int
 {
 	int ret = PCIBIOS_SUCCESSFUL, type;
 	u64 busdev;
+	struct sunxi_pcie *pci = to_sunxi_pcie_from_pp(pp);
 
 	busdev = PCIE_ATU_BUS(PCI_BUS(d)) | PCIE_ATU_DEV(PCI_DEV(d)) | PCIE_ATU_FUNC(PCI_FUNC(d));
 
-	if (PCI_BUS(d) != 0)
+	if (PCI_BUS(d) == pci->first_busno + 1)
 		type = PCIE_ATU_TYPE_CFG0;
 	else
 		type = PCIE_ATU_TYPE_CFG1;


### PR DESCRIPTION
Fix a PCIe enumeration hang observed on Allwinner/sunxi DesignWare PCIe when a downstream PCIe device (e.g. Radxa Dual 2.5G Router HAT) is present, by correcting CFG0/CFG1 config access and initializing RC bus numbers properly.

link: https://github.com/radxa/allwinner-device/pull/17