### PR TITLE
arm: dts: radxa cm5 io: remove usbhost_dwc3_0 high-speed limit

### DIFF
--- a/arch/arm/dts/rk3588s-radxa-cm5-io.dts
+++ b/arch/arm/dts/rk3588s-radxa-cm5-io.dts
@@ -530,7 +530,6 @@
 };
 
 &usbhost_dwc3_0 {
-	maximum-speed = "high-speed";
 	status = "okay";
 };
 


### PR DESCRIPTION
Fix the issue where USB 3.0 cannot be recognized after booting. So remove the maximum-speed restriction to enable USB 3.x super-speed for usbhost_dwc3_0 controller on Radxa CM5 IO.

https://redmine.rock-chips.com/issues/613264