### PR TITLE
Revert "drivers/video: drm: load file from primary part"

### DIFF
--- a/drivers/video/drm/sunxi_drm_drv.c
+++ b/drivers/video/drm/sunxi_drm_drv.c
@@ -822,7 +822,7 @@ static int load_bmp_logo(struct display_state *state, char *bmp_name)
 		state->logo = NULL;
 	}
 
-	state->logo = load_file(bmp_name, "primary");
+	state->logo = load_file(bmp_name, "bootloader");
 	if (!state->logo) {
 		state->logo = load_file(bmp_name, "boot-resource");
 	}


### PR DESCRIPTION
There is coupling between u-boot and kernel display, revert this commit to fix multiple display issues, including: unable to dual display, CLI image cannot display normally and other issues

This reverts commit 3897081e7fb27a6a26254a08deb144e7d65df00e.