### PR TITLE
sunxi: set default initrd_high to avoid BL31 and framebuffer overlap

### DIFF
--- a/include/configs/sunxi-common.h
+++ b/include/configs/sunxi-common.h
@@ -322,7 +322,8 @@
 	"scriptaddr=" SCRIPT_ADDR_R "\0" \
 	"pxefile_addr_r=" PXEFILE_ADDR_R "\0" \
 	"fdtoverlay_addr_r=" FDTOVERLAY_ADDR_R "\0" \
-	"ramdisk_addr_r=" RAMDISK_ADDR_R "\0"
+	"ramdisk_addr_r=" RAMDISK_ADDR_R "\0" \
+	"initrd_high=0x46400000\0"
 
 #ifdef CONFIG_VIDEO_SUNXI
 /*

--- a/include/configs/sunxi-common.h
+++ b/include/configs/sunxi-common.h
@@ -323,7 +323,7 @@
 	"pxefile_addr_r=" PXEFILE_ADDR_R "\0" \
 	"fdtoverlay_addr_r=" FDTOVERLAY_ADDR_R "\0" \
 	"ramdisk_addr_r=" RAMDISK_ADDR_R "\0" \
-	"initrd_high=0x46400000\0"
+	"initrd_high=0xffffffff\0"
 
 #ifdef CONFIG_VIDEO_SUNXI
 /*


### PR DESCRIPTION
Set initrd_high=0x46400000 in MEM_LAYOUT_ENV_SETTINGS to ensure ramdisk is allocated below the display framebuffer (0x46400000). This prevents ramdisk from overlapping with:
- Display framebuffer at 0x46400000-0x473fffff (16MB)
- BL31 reserved region at 0x48000000-0x48ffffff (16MB)

Without this setting, boot_ramdisk_high() may allocate ramdisk at 0x480cd000 which overlaps with BL31, causing boot failure with error: "reserving fdt memory region failed (addr=48000000 size=1000000)"

The 0x46400000 value leaves approximately 60-70MB space for ramdisk between kernel end and display framebuffer start.