### PR TITLE
Makefile: fix u-boot.itb dependency on u-boot.dtb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1056,7 +1056,7 @@ u-boot-dtb.img u-boot.img u-boot.kwb u-boot.pbl u-boot-ivt.img: \
 		$(if $(CONFIG_SPL_LOAD_FIT),u-boot-nodtb.bin dts/dt.dtb,u-boot.bin) FORCE
 	$(call if_changed,mkimage)
 
-u-boot.itb: u-boot-nodtb.bin dts/dt.dtb $(U_BOOT_ITS) FORCE
+u-boot.itb: u-boot-nodtb.bin dts/dt.dtb u-boot.dtb $(U_BOOT_ITS) FORCE
 	$(call if_changed,mkfitimage)
 
 u-boot-spl.kwb: u-boot.img spl/u-boot-spl.bin FORCE


### PR DESCRIPTION
## What changed

Add `u-boot.dtb` as an explicit prerequisite of `u-boot.itb`.

## Root cause

The Rockchip FIT generator references `./u-boot.dtb` for the FDT payload,
while the `u-boot.itb` target currently depends on `dts/dt.dtb`. The separate
`u-boot.dtb` copy target can therefore run concurrently with FIT generation
under parallel make.

If FIT generation reads the destination after `cp` truncates it but before the
copy completes, the build succeeds with a structurally valid `u-boot.itb`
whose required FDT payload is zero bytes.

Making the consumer depend on the file it actually reads orders the copy
before FIT generation.

## Impact

This prevents intermittent Rockchip FIT artifacts with the SHA-256 of empty
data for their FDT component. Such artifacts have been observed in official
Armbian builds and can leave RK3588 boards unable to boot from raw SD media.

Related downstream reports and workaround:

- armbian/build#8227
- armbian/build#9897
- armbian/build#9946

## Validation

- `make rock-5b-rk3588_defconfig`
- `make -pn u-boot.itb` reports:
  `u-boot.itb: u-boot-nodtb.bin dts/dt.dtb u-boot.dtb FORCE`
- `./scripts/checkpatch.pl --strict --git HEAD`: 0 errors, 0 warnings
- An Armbian ROCK 5B image containing a nonzero 12,752-byte control DTB booted
  successfully from microSD when installed with its matching loader pair.