### PR TITLE
fix(mmc): correct sunxi SPL clock and reset selection

### DIFF
--- a/arch/arm/include/asm/arch-sunxi/clock_sun50i_h6.h
+++ b/arch/arm/include/asm/arch-sunxi/clock_sun50i_h6.h
@@ -36,6 +36,9 @@
 #define CCU_H6_UART_GATE_RESET		0x90c
 #define CCU_H6_I2C_GATE_RESET		0x91c
 
+/* A523 CCU register offsets */
+#define CCU_A523_MMC_ASSOC_GATE		0xe04
+
 /* A733 CCU register offsets */
 #define CCU_A733_PLL6_CFG		0x0a0
 #define CCU_A733_APB_UART_CLK_CFG	0x538

--- a/drivers/mmc/sunxi_mmc.c
+++ b/drivers/mmc/sunxi_mmc.c
@@ -633,6 +633,13 @@ static void sunxi_mmc_set_clkrst(void *ccm, int sdc_no)
 	writel(SUNXI_MMC_COMMON_CLK_GATE | SUNXI_MMC_COMMON_RESET,
 	       SUNXI_MMC_COMMON_BASE + 4 * sdc_no);
 #endif
+#elif defined(CONFIG_MACH_SUN60I_A733)
+	setbits_le32(ccm + CCU_MMC_GATE_RESET(sdc_no), BIT(16) | BIT(0));
+#elif defined(CONFIG_MACH_SUN55I_A523)
+	setbits_le32(ccm + CCU_H6_MMC_GATE_RESET,
+		     (BIT(16) | BIT(0)) << sdc_no);
+	setbits_le32(ccm + CCU_A523_MMC_ASSOC_GATE,
+		     (BIT(17) | BIT(5)) << sdc_no);
 #elif  #defined(CONFIG_SUN50I_GEN_H6)
 	setbits_le32(ccm + CCU_H6_MMC_GATE_RESET, (BITR(16) | BIT(0)) << sdc_no);
 #else


### PR DESCRIPTION
The malformed H6 preprocessor condition selected the A733 register layout for H6 and other NCAT2 SoCs. Select A733 explicitly and use the shared H6 gate/reset register for the remaining SoCs.

Enable the A523/A527 associated bus gates per MMC controller, covering both SD and eMMC initialization in SPL.